### PR TITLE
Use Java 11 and Maven 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
 FROM docker:stable-dind
-LABEL maintainer="fbelzunc@gmail.com"
+# Keys were rotated in the edge repos, so we need to do this now
+RUN apk add -X https://dl-cdn.alpinelinux.org/alpine/v3.16/main -u alpine-keys --allow-untrusted
+# Workaround for  https://github.com/AdoptOpenJDK/openjdk-docker/issues/75
+RUN apk add --no-cache fontconfig ttf-dejavu openjdk11 bash tini bind-tools
+RUN apk add aufs-util --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
+RUN apk add maven --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
+# Workaround for  https://github.com/AdoptOpenJDK/openjdk-docker/issues/75
+RUN ln -s /usr/lib/libfontconfig.so.1 /usr/lib/libfontconfig.so && \
+    ln -s /lib/libuuid.so.1 /usr/lib/libuuid.so.1 && \
+    ln -s /lib/libc.musl-x86_64.so.1 /usr/lib/libc.musl-x86_64.so.1
+ENV LD_LIBRARY_PATH /usr/lib
 
-RUN apk add --no-cache maven openjdk8 bash tini bind-tools
-RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing aufs-util
-
-ENV JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk/
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk/
 #ENV DOCKER_STORAGE_DRIVER=overlay2
 ENV DOCKER_HOST=unix:///var/tmp/docker.sock
 

--- a/custom-dockerd-entrypoint.sh
+++ b/custom-dockerd-entrypoint.sh
@@ -4,14 +4,6 @@ DOCKER_OPTS="--config-file=/etc/docker/daemon.json"
 $(which dind) dockerd ${DOCKER_OPTS} >/dev/stdout 2>&1 &
 sleep 1
 java -version
-rm -rf docker-fixtures
-git clone https://github.com/jenkinsci/docker-fixtures.git
-cd docker-fixtures
-git fetch origin pull/4/head:JENKINS-46673
-git checkout JENKINS-46673
-mvn -Dmaven.test.skip=true -Dmaven.compiler.executable=1.7 -Dmaven.compiler.target=1.7 clean deploy
-cd ..
-export JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk/
 mvn --version
 mvn -B -Djenkins.test.timeout=1200 "$@"
 exit 0


### PR DESCRIPTION
Updates the docker image to use java 11 and maven 3.8, effectively fixing the pr builder on https://github.com/jenkinsci/active-directory-plugin/pull/142 and allowing further baseline bumps in active-directory plugin